### PR TITLE
Fix Broken Selection Highlighting

### DIFF
--- a/src/global/general.scss
+++ b/src/global/general.scss
@@ -14,11 +14,6 @@
 	}
 }
 
-::selection {
-	// background: $color-teal;
-	color: $color-black;
-}
-
 body {
 	background: $color-white;
 }


### PR DESCRIPTION
This is an easy fix - essentially the bug was that I was styling the psuedo selection element but without a background color (since teal wasnt a marble style.... I took it out and forgot to replace it).

The entire styling of the ::selection block was me just being cute so ripping this out feels safest. We can revisit styling this in the future if we'd like