### PR TITLE
default link underline

### DIFF
--- a/src/global/general.scss
+++ b/src/global/general.scss
@@ -79,6 +79,7 @@ input {
 }
 
 a {
+	@include underline($color-grey-900);
 	color: inherit;
 
 	&:visit,


### PR DESCRIPTION
Not sure how you guys feel about this. When I was bringing marble into collections, the link underlines were all off. I'm adding them here for consistency, what do you think?