### PR TITLE
Font size edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@metmuseum/marble",
-	"version": "0.11.11",
+	"version": "0.12.0",
 	"description": "The Design System of The Metropolitan Museum Of Art",
 	"main": "./src/index.mjs",
 	"style": "./dist/marble.css",

--- a/src/base/_sizes.scss
+++ b/src/base/_sizes.scss
@@ -57,9 +57,9 @@ $textsize-xxs: fontsize-calculator(12, 14);
 $textsize-xs: fontsize-calculator(14, 16);
 $textsize-s: fontsize-calculator(18, 20); //Body Text
 $textsize-m: fontsize-calculator(20, 24); //H4
-$textsize-l: fontsize-calculator(22, 32); //H3
-$textsize-xl: fontsize-calculator(32, 48); //H2
-$textsize-xxl: fontsize-calculator(48, 60); //H1
+$textsize-l: fontsize-calculator(24, 32); //H3
+$textsize-xl: fontsize-calculator(32, 42); //H2
+$textsize-xxl: fontsize-calculator(48, 54); //H1
 
 //The smaller value of the fluid type functions.
 //I chose to put these values in to the above function (instead of the variables) into the above function just for readability.


### PR DESCRIPTION
h1 desktop size reduced to 54px (from 60)
h2 desktop size reduced to 42px (currently 50)
h3 mobile size increased to 24px (currently 22)