### PR TITLE
Rte tools v2

### DIFF
--- a/src/components/rte-components/rte-components.scss
+++ b/src/components/rte-components/rte-components.scss
@@ -1,8 +1,13 @@
 .media__youtube-wrapper  {
-	height: 0;
+	aspect-ratio: 16 / 9;
 	overflow: hidden;
-	padding-bottom: 56.25%;
 	position: relative;
+	max-width: $line-length-max;
+
+	@supports not (aspect-ratio: 16 / 9 {
+		height: 0;
+		padding-bottom: 56.25%;
+	}
 
 	iframe,
 	object,

--- a/src/components/rte-components/rte-components.scss
+++ b/src/components/rte-components/rte-components.scss
@@ -2,7 +2,7 @@
 	aspect-ratio: 16 / 9;
 	overflow: hidden;
 	position: relative;
-	max-width: $line-length-max;
+	max-width: 60em;
 
 	@supports not (aspect-ratio: 16 / 9) {
 		height: 0;

--- a/src/components/rte-components/rte-components.scss
+++ b/src/components/rte-components/rte-components.scss
@@ -4,7 +4,7 @@
 	position: relative;
 	max-width: $line-length-max;
 
-	@supports not (aspect-ratio: 16 / 9 {
+	@supports not (aspect-ratio: 16 / 9) {
 		height: 0;
 		padding-bottom: 56.25%;
 	}
@@ -17,5 +17,100 @@
 		position: absolute;
 		top: 0;
 		width: 100%;
+	}
+}
+
+.rich-text {
+	box-sizing: border-box;
+	width: 100%;
+
+	h2,
+	h3,
+	h4 {
+		a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	ol,
+	ul,
+	p {
+		margin-bottom: $spacing-xxs;
+	}
+
+	ol,
+	ul {
+		max-width: $line-length-max;
+		padding-left: $spacing-xxs;
+	}
+
+	ol {
+		list-style: decimal;
+	}
+
+	ul {
+		list-style: disc;
+	}
+
+	li {
+		line-height: 1.4;
+		margin: 0;
+
+		& > ol,
+		& > ul {
+			margin-bottom: 0;
+		}
+	}
+
+	img {
+		height: auto !important;
+		width: 100% !important;
+		max-width: $line-length-max !important;
+	}
+
+	hr {
+		border-top: 2px solid $color-grey-500;
+		display: block;
+		height: 2px;
+		margin: $spacing-s 0;
+		width: 100%;
+
+		&.alt {
+			border-top: 1px solid $color-grey-200;
+			height: 1px;
+		}
+	}
+
+	table {
+		width: 100%;
+	}
+
+	strong {
+		font-weight: 700;
+	}
+
+	.inline-caption {
+		font-size: $textsize-xs;
+	}
+
+	.audio-player {
+		max-width: $line-length-max;
+	}
+
+	.btn {
+		display: inline-flex;
+	}
+
+	.btn,
+	.button {
+		margin-top: $spacing-micro;
+	}
+
+	*:last-child {
+		margin-bottom: 0;
 	}
 }

--- a/src/components/rte-components/rte-components.stories.js
+++ b/src/components/rte-components/rte-components.stories.js
@@ -1,32 +1,53 @@
 import html from "../../../.storybook/helpers/html";
 import { withKnobs, text } from "@storybook/addon-knobs";
-
+import metStoriesImage from "../../../.storybook/assets/images/misc/2020_Met_Stories_Ep_01_4k_NEW-3.jpg";
 export default {
-	title: "RTE Components/Media",
+	title: "RTE Components/All",
 	decorators: [withKnobs],
 };
 
 const data = () => {
 	return {
-		id: text(
+		h1: text("Headhing 1", "Heading One"),
+		h2: text("Headhing 2", "Heading Two"),
+		h3: text("Headhing 3", "Heading Three"),
+		h4: text("Headhing 4", "Heading Four"),
+		p1: text("Paragraph 1", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin consectetur accumsan ligula, ac gravida nibh. Nulla vitae placerat odio. Nullam ac mattis arcu. Fusce mattis non lorem a consectetur. Phasellus eu nunc non justo ullamcorper feugiat. Nam ac dictum eros. Nulla facilisi. Fusce consectetur, arcu et mattis convallis, velit leo aliquam urna, in malesuada nunc nulla sit amet felis. Aliquam tempor volutpat leo, sed gravida metus tempor non. Proin iaculis lobortis massa, vel vehicula nisl aliquet ut. Vivamus rhoncus lacus lacus, et bibendum libero viverra in. Vivamus id eros arcu. Ut libero lectus, vulputate sit amet nibh id, egestas rhoncus leo. Sed nec tortor bibendum, pulvinar elit et, dignissim ligula. Pellentesque ut est justo."),
+		p2: text("Paragraph 1", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin consectetur accumsan ligula, ac gravida nibh. Nulla vitae placerat odio. Nullam ac mattis arcu. Fusce mattis non lorem a consectetur. Phasellus eu nunc non justo ullamcorper feugiat. Nam ac dictum eros. Nulla facilisi. Fusce consectetur, arcu et mattis convallis, velit leo aliquam urna, in malesuada nunc nulla sit amet felis. Aliquam tempor volutpat leo, sed gravida metus tempor non. Proin iaculis lobortis massa, vel vehicula nisl aliquet ut. Vivamus rhoncus lacus lacus, et bibendum libero viverra in. Vivamus id eros arcu. Ut libero lectus, vulputate sit amet nibh id, egestas rhoncus leo. Sed nec tortor bibendum, pulvinar elit et, dignissim ligula. Pellentesque ut est justo."),
+		youtubeId: text(
 			"Youtube Video ID",
 			"kSYaFH1H-uo"
-		)
+		),
+		backgroundImage: `${metStoriesImage}`,
+		inlineCaption: text("Inline Caption", "This is a curious little snippet we use for an `inline caption`")
 	};
 };
 
 //Responsive 16x9 wrapper for YouTube videos
 const YoutubeEmbedMarkUp = (model) => {
 	return html`
-	<div class="media__youtube-wrapper">
-		<iframe
-			title="Youtube Embed"
-			width="720"
-			height="428"
-			src="https://www.youtube.com/embed/${model.id}?rel=0"
-			frameborder="0"
-			allow="autoplay; encrypted-media">
-		</iframe>
+	<div class="rich-text" style="margin: 40px">
+		<h1>${model.h1}</h1>
+		<h2>${model.h2}</h2>
+		<h3>${model.h3}</h3>
+		<h3>${model.h4}</h3>
+		<hr>
+		<div class="media__youtube-wrapper">
+			<iframe
+				title="Youtube Embed"
+				width="720"
+				height="428"
+				src="https://www.youtube.com/embed/${model.youtubeId}?rel=0"
+				frameborder="0"
+				allow="autoplay; encrypted-media">
+			</iframe>
+		</div>
+		<hr>
+		</hr>
+		<p>${model.p1}</p>
+		<img src="${model.backgroundImage}" alt="RTE Image">
+		<div class="inline-caption">${model.inlineCaption}</div>
+		<p>${model.p2}</p>
 	</div>
 	`;
 };

--- a/src/components/rte-components/rte-components.stories.js
+++ b/src/components/rte-components/rte-components.stories.js
@@ -24,9 +24,9 @@ const data = () => {
 };
 
 //Responsive 16x9 wrapper for YouTube videos
-const YoutubeEmbedMarkUp = (model) => {
+const RTEComponentsMarkUp = (model) => {
 	return html`
-	<div class="rich-text" style="margin: 40px">
+	<div class="rich-text" style="margin: 40px auto; max-width: 85%;">
 		<h1>${model.h1}</h1>
 		<h2>${model.h2}</h2>
 		<h3>${model.h3}</h3>
@@ -52,7 +52,7 @@ const YoutubeEmbedMarkUp = (model) => {
 	`;
 };
 
-export const YoutubeEmbed = () => {
+export const RTEComponents = () => {
 	const storyData = data();
-	return html`${YoutubeEmbedMarkUp(storyData)}`;
+	return html`${RTEComponentsMarkUp(storyData)}`;
 };


### PR DESCRIPTION
Built out more of the RTE tool snippets. 

I copied the RTE stylesheet we use in Zodiac and Ghidorah and made very minimal changes. We can iterate on this, but I'd like to start at the baseline of "moving what we already have into marble".

The other big change was adding a max-width to video and audio-player's inserted into an RTE. The audio player case doesn't exist yet (There are no RTEs on our site that embed one, but I figured it was a safe future-proof).

The youtube video max-width came from a ticket in Audience and from the UX guidance of Madhav.