### PR TITLE
Ci npm cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,14 @@ jobs:
       - checkout
       - run: node --version
       - run: npm --version
+      - restore_cache:
+          keys:
+          - npm-cache-{{ checksum "package-lock.json" }}
       - run: npm ci
+      - save_cache:
+          key: npm-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/.npm
       - run: npm run lint
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,12 @@ version: 2.1
 executors:
   marble-node:
     docker:
-      - image: "cimg/python:3.9-node"
+      - image: "cimg/node:lts"
 jobs:
   setup_marble:
     executor: marble-node
     steps:
       - checkout
-      - run: python --version
       - run: node --version
       - run: npm --version
       - run: npm ci


### PR DESCRIPTION
**Them:** cache the repo's local `node_modules` and only use `npm install` 
**Me, an intellectual:** cache _npm's cache_ and use `npm ci` 