### PR TITLE
simplified carousel slide mixin and fixed alignment bug

### DIFF
--- a/src/base/mixins/_mixins.scss
+++ b/src/base/mixins/_mixins.scss
@@ -17,31 +17,25 @@
 @mixin carousel-slide(
 	$gutter: $spacing-xxs,
 	$slideMaxWidth: 85vw,
+	$width: auto,
 	$leftRightOffset: $spacing-component-margin
 ) {
-	flex-shrink: 0;
-	margin-left: $gutter;
-	max-width: $slideMaxWidth;
-	
-	&:last-child,
-	&:first-child {
-		max-width: calc($slideMaxWidth + $leftRightOffset);
-	}
 
+	border-left: $gutter transparent solid;
+	box-sizing: content-box;
+	flex-shrink: 0;
+	max-width: $slideMaxWidth;
+	width: $width;
+	
 	&:first-child {
-		padding-left: $leftRightOffset;
+		border-left: $leftRightOffset transparent solid;
 	}
 
 	&:last-child {
-		padding-right: $leftRightOffset;
+		border-right: $leftRightOffset transparent solid;
 	}
-}
 
-@mixin carousel-slide-fixed-width($slideWidth: 550px, $leftRightOffset: $spacing-component-margin) {
-	width: $slideWidth;
-
-	&:last-child,
-	&:first-child {
-		width: calc(#{$slideWidth} + #{$leftRightOffset});
+	* {
+		box-sizing: border-box;
 	}
 }

--- a/src/components/carousel/slide/carousel-slide.scss
+++ b/src/components/carousel/slide/carousel-slide.scss
@@ -4,10 +4,10 @@
 	@include carousel-slide;
 }
 
-.carousel-slide--fixed-width {
-	@include carousel-slide-fixed-width();
+//Just a demo class for Storybook
+.sb-carousel-slide--fixed-width {
+	@include carousel-slide($width: 550px);
 }
-
 
 .carousel-slide__media-wrapper {
 	margin-bottom: $spacing-xxs;

--- a/src/components/carousel/slide/carousel-slide.stories.js
+++ b/src/components/carousel/slide/carousel-slide.stories.js
@@ -18,7 +18,7 @@ const args = {
 export const CarouselSlide = (args) => {
 	useEffect(videoSlide);
 	return html`
-		<div class="carousel-slide ${args.variableWidth ? "carousel-slide--variable-width" : "carousel-slide--fixed-width"} js-carousel-slide">
+		<div class="carousel-slide ${args.variableWidth ? "carousel-slide--variable-width" : "sb-carousel-slide--fixed-width"} js-carousel-slide">
 			${mediaMarkUp(args)}
 			<div class="carousel-slide__subject">
 				<h3 class="carousel-slide__header">${args.header} ${args.index ? args.index : ""}</h3>


### PR DESCRIPTION
I had to rethink this mixin.

Flickity doesnt respect `margin` the way I expected it too, so I refactored to use a clear border. It's working well in some use cases in Sculptured right now. 